### PR TITLE
Add short and long name for functions and mixins

### DIFF
--- a/src/framework/_breakpoints.scss
+++ b/src/framework/_breakpoints.scss
@@ -24,7 +24,7 @@ $breakpoints: (
  * @param  {string} $unit            The unit for the media queries (em or px)
  * @return {string}                  A media query expression
  */
-@function md($breakpoint, $type: 'min', $unit: 'em') {
+@function media($breakpoint, $type: 'min', $unit: 'em') {
   @if not map-has-key($breakpoints, $breakpoint) {
     @error 'No breakpoint found in $breakpoints map for `#{$breakpoint}`.';
   }
@@ -58,4 +58,11 @@ $breakpoints: (
       @return 'not all and (min-width: #{$size})';
     }
   }
+}
+
+/**
+ * Alias of the `media($breakpoint, $type, $unit)` function above
+ */
+@function md($breakpoint, $type: 'min', $unit: 'em') {
+  @return media($breakpoint, $type, $unit);
 }

--- a/src/framework/_colors.scss
+++ b/src/framework/_colors.scss
@@ -15,12 +15,19 @@ $colors: (
  * @param  {string} $color The name of the color
  * @return {number}        The value corresponding to the color's name
  */
-@function c($color) {
+@function color($color) {
   @if not map-has-key($colors, $color) {
     @warn 'No color found in $colors map for `#{$color}`. Property omitted.';
   }
 
   @return map-get($colors, $color);
+}
+
+/**
+ * Alias for the `color($color)` function above
+ */
+@function c($color) {
+  @return color($color);
 }
 
 /*============================================================================*\

--- a/src/framework/_layers.scss
+++ b/src/framework/_layers.scss
@@ -17,11 +17,11 @@ $layers: (
  * A function helper to avoid having to type `map-get($layers, ...)`
  * Based on http://css-tricks.com/handling-z-index/
  *
- * @param  {string} $layer The name of the z-index
- * @param  {number} $var   The modifier if needed
- * @return {number}        The corresponding z-index based on the $layers var
+ * @param  {string} $layer    The name of the z-index
+ * @param  {number} $modifier The modifier if needed
+ * @return {number}           The corresponding z-index based on the $layers var
  */
-@function z($layer, $var: 0) {
+@function layer($layer, $modifier: 0) {
   @if not map-has-key($layers, $layer) {
     @warn 'No z-index found in $layers map for `#{$layer}`. Property omitted.';
     @return 'initial';
@@ -29,4 +29,21 @@ $layers: (
 
   $value: map-get($layers, $layer);
   @return $value + $var;
+}
+
+/**
+ * Alias for the `layer($layer, $modifier)` function above
+ */
+@function l($layer, $modifier: 0) {
+  @return layer($layer, $modifier);
+}
+
+/**
+ * Deprecated alias for the `layer($layer, $modifier)` function
+ */
+@function z($layer, $modifier: 0) {
+  @warn 'The `z($layer, $modifier)` function is deprecated.';
+  @warn 'Use `l($layer, $modifier)` instead.';
+
+  @return l($layer, $modifier);
 }

--- a/src/framework/_spaces.scss
+++ b/src/framework/_spaces.scss
@@ -41,9 +41,11 @@ $spaces: (
 }
 
 /**
- * Space gutter
+ * Alias for the `space($space)` function above
  */
-$space-gutter: space('x6');
+@function s($space) {
+  @return space($space);
+}
 
 /*============================================================================*\
    Spaces class helpers

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -78,7 +78,7 @@ $font-sizes: (
  * @param  {number} $var   The modifier if needed
  * @return {number}        The corresponding z-index based on the $layers var
  */
-@function fz($font-size, $unit: 'em') {
+@function font-size($font-size, $unit: 'em') {
   @if not map-has-key($font-sizes, $font-size) {
     @error 'No font-size found in $fonti-sizes map for `#{$font-size}`.';
   }
@@ -101,11 +101,18 @@ $font-sizes: (
 }
 
 /**
+ * Alias for the `font-size($font-size, $unit)` function above
+ */
+@function fz($font-size, $unit: 'em') {
+  @return font-size($font-size, $unit);
+}
+
+/**
  * A function helper to get the computed line-height of the given font-size
  * @param  {string} $font-size The name of the font-size
  * @return {string}            The corresponding line-height
  */
-@function lh($font-size) {
+@function line-height($font-size) {
   @if not map-has-key($font-sizes, $font-size) {
     @error 'No font-size found in $fonti-sizes map for `#{$font-size}`.';
   }
@@ -123,14 +130,28 @@ $font-sizes: (
 }
 
 /**
+ * Alias for the `line-height($font-size)` function above
+ */
+@function lh($font-size) {
+  @return line-height($font-size);
+}
+
+/**
  * A mixin to get both font-size and line-height given a named font-size
  * @param  {string} $font-size The font-size name
  * @param  {string} $unit      The unit for the font-size value
  * @return {string}            The `font-size` and `line-height` declarations
  */
-@mixin fz($font-size, $unit: 'em') {
+@mixin font-size($font-size, $unit: 'em') {
   font-size: fz($font-size, $unit);
   line-height: lh($font-size);
+}
+
+/**
+ * Alias for the `font-size($font-size, $unit)` mixin defined above
+ */
+@mixin fz($font-size, $unit: 'em') {
+  @include font-size($font-size, $unit);
 }
 
 /*============================================================================*\


### PR DESCRIPTION
For more consistency, every long-named function/mixin now has a short-named alias and every short-named has been transformed into an alias of a long-named function/mixin.

See https://github.com/studiometa/scss-toolkit/projects/1#card-16427930.