### PR TITLE
Refactor font-weight declarations.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -440,7 +440,7 @@ $spaces: (0, 1, 2, 4, 8, 16, auto) !default;
   + `.type-serif`: set the font-family property to the `$font-family-serif` value
   + `.type-sans`: set the font-family property to the `$font-family-sans` value
   + `.type-<weight>[--<breakpoin>]`: set the `font-weight` property to the given `<weight>`, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint
-    * `<weight>`: one of `thin`, `extralight`, `light`, `regular`, `medium`, `semibold`, `bold`, `extrabold`, `black`
+    * `<weight>`: one of `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
   + `.type-spacing-<value>[--<breakpoint>]`: set the `letter-spacing` property to the given value, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint
     * `<value>`: one of `25`, `50`, `100`, `200`

--- a/readme.md
+++ b/readme.md
@@ -439,7 +439,7 @@ $spaces: (0, 1, 2, 4, 8, 16, auto) !default;
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
   + `.type-serif`: set the font-family property to the `$font-family-serif` value
   + `.type-sans`: set the font-family property to the `$font-family-sans` value
-  + `.type-<weight>[--<breakpoin>]`: set the `font-weight` property to the given `<weight>`, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint
+  + `.type-<weight>[--<breakpoint>]`: set the `font-weight` property to the given `<weight>`, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint
     * `<weight>`: one of `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
   + `.type-spacing-<value>[--<breakpoint>]`: set the `letter-spacing` property to the given value, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -331,7 +331,7 @@ $font-sizes: (
 /*============================================================================*\
    Type font weight helpers
 \*============================================================================*/
-$font-weights: (300, 500, 800) !default;
+$font-weights: (300, 400, 700) !default;
 
 @if $has-classes {
   @each $font-weight in $font-weights {

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -115,7 +115,7 @@ $font-sizes: (
  */
 @function line-height($font-size) {
   @if not map-has-key($font-sizes, $font-size) {
-    @error 'No font-size found in $fonti-sizes map for `#{$font-size}`.';
+    @error 'No font-size found in $font-sizes map for `#{$font-size}`.';
   }
 
   $values: map-get($font-sizes, $font-size);
@@ -331,42 +331,13 @@ $font-sizes: (
 /*============================================================================*\
    Type font weight helpers
 \*============================================================================*/
+$font-weights: (300, 500, 800) !default;
 
 @if $has-classes {
-  .type-thin {
-    font-weight: 100;
-  }
-
-  .type-extralight {
-    font-weight: 200;
-  }
-
-  .type-light {
-    font-weight: 300;
-  }
-
-  .type-regular {
-    font-weight: 400;
-  }
-
-  .type-medium {
-    font-weight: 500;
-  }
-
-  .type-semibold {
-    font-weight: 600;
-  }
-
-  .type-bold {
-    font-weight: 700;
-  }
-
-  .type-extrabold {
-    font-weight: 800;
-  }
-
-  .type-black {
-    font-weight: 900;
+  @each $font-weight in $font-weights {
+    .type-weight-#{$font-weight} {
+      font-weight: $font-weight;
+    }
   }
 
   /**
@@ -375,41 +346,11 @@ $font-sizes: (
   @each $breakpoint in $breakpoints {
     $breakpoint: nth($breakpoint, 1);
 
-    @media #{md($breakpoint)} {
-      .type-thin--#{$breakpoint} {
-        font-weight: 100;
-      }
-
-      .type-extralight--#{$breakpoint} {
-        font-weight: 200;
-      }
-
-      .type-light--#{$breakpoint} {
-        font-weight: 300;
-      }
-
-      .type-regular--#{$breakpoint} {
-        font-weight: 400;
-      }
-
-      .type-medium--#{$breakpoint} {
-        font-weight: 500;
-      }
-
-      .type-semibold--#{$breakpoint} {
-        font-weight: 600;
-      }
-
-      .type-bold--#{$breakpoint} {
-        font-weight: 700;
-      }
-
-      .type-extrabold--#{$breakpoint} {
-        font-weight: 800;
-      }
-
-      .type-black--#{$breakpoint} {
-        font-weight: 900;
+    @media all and #{md($breakpoint)} {
+      @each $font-weight in $font-weights {
+        .type-weight-#{$font-weight}--#{$breakpoint} {
+          font-weight: $font-weight;
+        }
       }
     }
   }


### PR DESCRIPTION
Resolve #16 

And reduce the number of lines to handle `font-weight`. 
I did not put all possible values as default : `$font-weights: (100, 200, 300, 400, 500, 600, 700, 800, 900) !default;` to avoid generating too much classes that won't be used in a project.