### PR TITLE
Improve the typography configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -427,95 +427,119 @@ $spaces: (0, 1, 2, 4, 8, 16, auto) !default;
 
 **Definitions**
 
-- `$font-dir`: path to the folder of your webfont files, must be of `*.woff` and `*.woff2` formats
-- `$font-name-serif`: the name of the serif font, to be used in `font-family` property
-- `$font-name-sans`: the name of the sans-serif font, to be used in `font-family` property
-- `$font-family-serif`: the serif `font-family` declaration
-- `$font-family-sans`: the sans-serif `font-family` declaration
-- `$font-faces`: a map of font-faces declaration structured as `<font-name> <filename> <font-weight> <font-style>`
-  + `<font-name>`: can be one of the `$font-name-serif` or `$font-name-sans` variables
-  + `<filename>`: the name of the file stored in the `$font-dir` folder
-  + `<font-weight>`: the weight of the font, from `100` to `900`
-  + `<font-style>`: a `font-style` value
-- `$font-sizes`: a map of font-sizes lists to be used in your project structured as `<name>: (<font-size> <line-height>)`
+- `@mixin reponsize-type($min-width: 0, $max-width: 2560, $min-size: 12, $max-size: 16)`: a mixin to generate declaration for responsive font-sizes
+- `@mixin type-antialiased`: a mixin to generate properties for antialiased font rendering
+- `$type-sizes`: a map of font-sizes lists to be used in your project structured as `<name>: ( size: <font-size>[, line-height: <line-height>][, weight: <font-weight>])`
   + `<name>`: the name of the size
   + `<font-size>`: the `font-size` value in pixels
   + `<line-height>`: the `line-height` value in pixels
-- `@function font-size($font-size, $unit: 'em')`: a function to get a font-size value in the given unit by its name defined in the `$font-sizes` map
-- `@function fz($font-size, $unit)`: alias for the `font-size($font-size, $unit)` function
-- `@function line-height($font-size)`: a function to get a unitless line-height value by its name defined in the `$font-sizes` map
-- `@function lh($font-size)`: alias for the `line-height($font-size)` function
-- `@mixin font-size($font-size, $unit: 'em')`: a mixin to get both font-size in the given unit and line-height for a given name defined in the `$font-size` map
-- `@mixin fz($font-size, $unit)`: alias for the `@include font-size($font-size, $unit)` mixin
-- `@mixin reponsize-type($min-width: 0, $max-width: 2560, $min-size: 12, $max-size: 16)`: a mixin to generate declaration for responsive font-sizes
-- `@mixin type-antialiased`: a mixin to generate properties for antialiased font rendering
+  + `<font-weight>`: the unitless `font-weight` value
+- `@mixin font-size($font-size, $unit: 'em')`: a mixin to get CSS properties of the given name defined in the `$font-size` map
+- `@mixin fz($font-size, $unit: 'em')`: alias for the `@include font-size($font-size, $unit)` mixin
+- `$type-webfont-dir`: path to the folder of your webfont files (which must be of `*.woff` and `*.woff2` formats)
+- `$type-webfont-display`: the `font-display` property that will be applied to the `@font-faces` declarations
+- `$type-fonts: (<identifier>: <definition>)`: a map of font identifiers
+  + `<identifier>`: a unique font name, will be used to generate helper classes
+  + `<definition>: (stack: <font-family>, [name: <font-name>, webfonts: <webfonts>)`: a map defining the font stack and its webfonts if needed 
+    * `<stack>`: the full stack of fonts and their fallbacks, will be used to declare the `font-family` property
+    * `<font-name>`: the name of the font, used to set the `font-family` property in the `@font-faces` declaration
+    * `<webfonts>: (filename: <filename>, weight: <font-weight>, style: <font-style>)`: a list of maps containing the filename, weight and style of each wbefont to declare in an `@font-faces` statement
+      - `<filename>`: the name of the `woff` and `woff2` files of your webfont, without extension
+      - `<font-weight>`: the weight corresponding to the given filename (a number from `100` to `900`)
+      - `<font-style>`: the style of the given filename (`normal`, `italic`, etc.)
 - Class helpers:
-  + An `@font-face` declaration based on the `$font-faces` list
   + `.type-antialiased`: a class implementing the `type-antialiased` mixin
   + `.type[-rem]-<size>[--<breakpoint>]`: set the `font-size` in `em` and `line-height` properties to the given `<size>` defined values, with the `-rem` variation setting the `font-size` unit in `rem` and the `<breakpoint>` modifier applying the styles to the corresponding breakpoint
     * `<size>`: a name defined in the `$font-sizes` map
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
-  + `.type-<position>[--<breakpoint>]`: set the `text-align` property, with the `<breakpoint>` modifier applying the styles to the corresponding breakpoint
-    * `<position>`: one of `center`, `left`, `right`
+  + `.type-<font-name>`: set the `font-family` property to the corresponding stack in the `$type-fonts` map
+    * `<font-name>`: the unique identifier given to the font
+  + `.type-align-<alignment>[--<breakpoint>]`: set the `text-align` property, with the `<breakpoint>` modifier applying the styles to the corresponding breakpoint
+    * `<alignment>`: one of the value defined in the `$type-alignments` map, `center`, `left`, or `right` by defaults
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
-  + `.type-serif`: set the font-family property to the `$font-family-serif` value
-  + `.type-sans`: set the font-family property to the `$font-family-sans` value
   + `.type-<weight>[--<breakpoint>]`: set the `font-weight` property to the given `<weight>`, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint
-    * `<weight>`: one of `100`, `200`, `300`, `400`, `500`, `600`, `700`, `800`, `900`
+    * `<weight>`: one of the value defined in the `$type-weights` map, `300`, `400` or `700` by defaults
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
   + `.type-spacing-<value>[--<breakpoint>]`: set the `letter-spacing` property to the given value, with the `<breakpoint>` modifier applying the style to the corresponding breakpoint
-    * `<value>`: one of `25`, `50`, `100`, `200`
+    * `<value>`: one of the value defined in the `$type-spacings` map, `25`, `50`, `100`, `200` by defaults
     * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
-  + `.type-uppercase`: set the `text-transform` property to `uppercase`
-  + `.type-lowercase`: set the `text-transform` property to `lowercase`
-  + `.type-capitalize`: set the `text-transform` property to `capitalize`
-  + `.type-no-underline`: set the `text-decoration` property to `none`
-  + `.type-underline`: set the `text-decoration` property to `underline`
-  + `body`: set the `font-family` property on the `body` to the value of the `$font-family-sans` variable
-  + `h1, h2, h3, h4`: set the `font-family` property on the first 4 levels of heading to the value of the `$font-family-serif` variable
-  + `a`: set the `color` property on the `a` HTML element to `inherit`
+  + `.type-transform-<transform>`: set the `text-transform` property to the given `<transform>`
+    * `<transform>`: one of the value defined in the `$type-transforms` map, `uppercase`, `lowercase` or `capitalize` by defaults
+  + `.typ-decoration-<decoration>`: set the `text-decoration` property to the given `<decoration>` value
+    * `<decoration>`: one of the value defined in the `$type-decorations` map, `none` or `underline` by defaults
 
 **Defaults**
 
 ```scss
-$font-dir: '/source/fonts/' !default;
-$font-name-serif: Georgia !default;
-$font-name-sans: Arial !default;
-$font-family-serif: $font-name-serif, serif !default;
-$font-family-sans: $font-name-sans, sans-serif !default;
-
-$font-faces: (
-  $font-name-serif 'type-serif-regular' 400 normal,
-  $font-name-sans 'type-sans-regular' 400 normal
+$type-sizes: (
+  display-1: (
+    size: 32px,
+    line-height: 48px,
+    weight: 700,
+  ),
+  display-2: (
+    size: 24px,
+    line-height: 36px,
+    weight: 700,
+  ),
+  body: (
+    size: 16px,
+  ),
+  small: (
+    size: 12px,
+  ),
 ) !default;
 
-$font-sizes: (
-  display-3: ( 44px, 66px ),
-  display-2: ( 36px, 54px ),
-  display-1: ( 24px, 32px ),
-  display-0: ( 18px, 27px ),
-  body:      ( 16px, 30px ),
-  medium:    ( 14px, 26px ),
-  small:     ( 12px, 22px ),
-  smaller:   ( 10px, 18px ),
+$type-webfont-dir: '/source/fonts/' !default;
+$type-webfont-display: auto !default;
+
+$type-fonts: (
+  serif: (
+    name: Georgia,
+    stack: 'Georgia, serif',
+    webfonts: (
+      (
+        filename: 'georgia-regular',
+        weight: 400,
+        style: normal,
+      ),
+    ),
+  ),
+  sans-serif: (
+    name: Arial,
+    stack: 'Arial, sans-serif',
+    webfonts: (
+      (
+        filename: 'arial-regular',
+        weight: 400,
+        style: normal,
+      ),
+    ),
+  ),
 ) !default;
+
+$type-alignments: (left, center, right) !default;
+$type-weights: (300, 400, 700) !default;
+$type-spacings: (25, 50, 100, 200) !default;
+$type-transforms: (uppercase, lowercase, capitalize) !default;
+$type-decorations: (none, underline) !default;
 ```
 
 **Usage**
 
 ```scss
-.foo__title {
-  @include fz('display-3');
+.title {
+  @include fz('display-1');
   @include type-antialiased;
 }
 ```
 
 ```html
 <!-- Adjust the size of a title on different breakpoints -->
-<h1 class="type-display-1--xxs type-display-2--s type-display-3--l">Foo Bar</h1>
+<h1 class="type-display-1--xxs type-display-2--s">Foo Bar</h1>
 
 <!-- Center a text -->
-<p class="type-center">Lorem ipsum dolor…</p>
+<p class="type-align-center">Lorem ipsum dolor…</p>
 ```
 
 

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -49,11 +49,13 @@ $has-classes: false !default;
 }
 
 @if $has-classes {
-  html,
-  input,
-  button,
   .type-antialiased {
-    @include type-antialiased;
+
+    &,
+    input,
+    button {
+      @include type-antialiased;
+    }
   }
 }
 
@@ -61,133 +63,55 @@ $has-classes: false !default;
  * A map to define all type-sizes and their corresponding line-heights, the
  * first value is the font-size, the seconde the line-height.
  *
- * The `fz($type-size, $unit)` and the `lh($type-size)` functions below can be
- * used to get easily one of the two values.
- *
  * @type {Map}
  */
 $type-sizes: (
-  'display-3': (
-    44px,
-    66px,
+  display-1: (
+    size: 32px,
+    line-height: 48px,
+    weight: 700,
   ),
-  'display-2': (
-    36px,
-    54px,
+  display-2: (
+    size: 24px,
+    line-height: 36px,
+    weight: 700,
   ),
-  'display-1': (
-    24px,
-    32px,
+  body: (
+    size: 16px,
   ),
-  'display-0': (
-    18px,
-    27px,
-  ),
-  'title-small': (
-    20px,
-    26px,
-  ),
-  'title-smaller': (
-    18px,
-    24px,
-  ),
-  'body': (
-    16px,
-    30px,
-  ),
-  'medium': (
-    14px,
-    26px,
-  ),
-  'small': (
-    12px,
-    22px,
-  ),
-  'smaller': (
-    10px,
-    18px,
+  small: (
+    size: 12px,
   ),
 ) !default;
 
-/*============================================================================*\
-   Type sizes helper functions and mixins
-\*============================================================================*/
-
-/**
- * A function helper to avoid having to type `map-get($layers, ...)`
- * Based on http://css-tricks.com/handling-z-index/
- *
- * @param  {string} $layer The name of the z-index
- * @param  {number} $var   The modifier if needed
- * @return {number}        The corresponding z-index based on the $layers var
- */
-@function font-size($type-size, $unit: 'em') {
-  @if not map-has-key($type-sizes, $type-size) {
-    @error 'No font-size found in $fonti-sizes map for `#{$type-size}`.';
-  }
-
-  $root-font-size: 16px;
-  $values: map-get($type-sizes, $type-size);
-
-  // First value is the font-size
-  $type-size: nth($values, 1);
-
-  // Second value is the line-height, we divide it by the font-size to get
-  // a line-height without unit, which is a best practice.
-  $line-height: nth($values, 2) / $type-size;
-
-  @if $unit == 'px' {
-    @return $type-size;
-  } @else {
-    @return #{$type-size / $root-font-size + $unit};
-  }
-}
-
-/**
- * Alias for the `font-size($type-size, $unit)` function above
- */
-@function fz($type-size, $unit: 'em') {
-  @return font-size($type-size, $unit);
-}
-
-/**
- * A function helper to get the computed line-height of the given font-size
- * @param  {string} $type-size The name of the font-size
- * @return {string}            The corresponding line-height
- */
-@function line-height($type-size) {
-  @if not map-has-key($type-sizes, $type-size) {
-    @error 'No font-size found in $type-sizes map for `#{$type-size}`.';
-  }
-
-  $values: map-get($type-sizes, $type-size);
-
-  // First value is the font-size
-  $type-size: nth($values, 1);
-
-  // Second value is the line-height, we divide it by the font-size to get
-  // a line-height without unit, which is a best practice.
-  $line-height: nth($values, 2) / $type-size;
-
-  @return $line-height;
-}
-
-/**
- * Alias for the `line-height($type-size)` function above
- */
-@function lh($type-size) {
-  @return line-height($type-size);
-}
-
 /**
  * A mixin to get both font-size and line-height given a named font-size
+ *
  * @param  {string} $type-size The font-size name
  * @param  {string} $unit      The unit for the font-size value
  * @return {string}            The `font-size` and `line-height` declarations
  */
 @mixin font-size($type-size, $unit: 'em') {
-  font-size: fz($type-size, $unit);
-  line-height: lh($type-size);
+  @if not map-has-key($type-sizes, $type-size) {
+    @error 'No font-size found in $type-sizes map for `#{$type-size}`.';
+  }
+
+  $type-size: map-get($type-sizes, $type-size);
+  $font-size: map-get($type-size, 'size');
+
+  @if $unit == 'px' {
+    font-size: $font-size;
+  } @else {
+    font-size: #{$font-size / 16px + $unit};
+  }
+
+  @if map-has-key($type-size, 'weight') {
+    font-weight: map-get($type-size, 'weight');
+  }
+
+  @if map-has-key($type-size, 'line-height') {
+    line-height: map-get($type-size, 'line-height') / $font-size;
+  }
 }
 
 /**
@@ -247,21 +171,6 @@ $type-fonts: (
         weight: 400,
         style: normal,
       ),
-      (
-        filename: 'georgia-italic',
-        weight: 400,
-        style: italic,
-      ),
-      (
-        filename: 'georgia-bold',
-        weight: 700,
-        style: normal,
-      ),
-      (
-        filename: 'georgia-bold-italic',
-        weight: 700,
-        style: italic,
-      ),
     ),
   ),
   sans-serif: (
@@ -273,21 +182,6 @@ $type-fonts: (
         weight: 400,
         style: normal,
       ),
-      (
-        filename: 'arial-italic',
-        weight: 400,
-        style: italic,
-      ),
-      (
-        filename: 'arial-bold',
-        weight: 700,
-        style: normal,
-      ),
-      (
-        filename: 'arial-bold-italic',
-        weight: 700,
-        style: italic,
-      ),
     ),
   ),
 ) !default;
@@ -296,26 +190,28 @@ $type-fonts: (
   @each $font in $type-fonts {
     $key: nth($font, 1);
     $font: map-get($type-fonts, $key);
-    $name: map-get($font, 'name');
     $stack: map-get($font, 'stack');
-    $webfonts: map-get($font, 'webfonts');
 
     .type-#{$key} {
       font-family: unquote($stack);
     }
 
-    @each $webfont in $webfonts {
-      $file: map-get($webfont, 'filename');
-      $weight: map-get($webfont, 'weight');
-      $style: map-get($webfont, 'style');
+    @if map-has-key($font, 'webfonts') and map-has-key($font, 'name') {
+      $name: map-get($font, 'name');
+      $webfonts: map-get($font, 'webfonts');
+      @each $webfont in $webfonts {
+        $file: map-get($webfont, 'filename');
+        $weight: map-get($webfont, 'weight');
+        $style: map-get($webfont, 'style');
 
-      @font-face {
-        font-family: $name;
-        src: url('#{$type-webfont-dir + $file}.woff2') format('woff2'),
-          url('#{$type-webfont-dir + $file}.woff') format('woff');
-        font-weight: $weight;
-        font-style: $style;
-        font-display: $type-webfont-display;
+        @font-face {
+          font-family: $name;
+          src: url('#{$type-webfont-dir + $file}.woff2') format('woff2'),
+            url('#{$type-webfont-dir + $file}.woff') format('woff');
+          font-weight: $weight;
+          font-style: $style;
+          font-display: $type-webfont-display;
+        }
       }
     }
   }

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -3,28 +3,70 @@
 \*============================================================================*/
 
 $has-classes: false !default;
-$font-dir: '/source/fonts/' !default;
-$font-name-serif: Georgia !default;
-$font-name-sans: Arial !default;
-$font-family-serif: $font-name-serif, serif !default;
-$font-family-sans: $font-name-sans, sans-serif !default;
-$font-display: auto !default;
 
-$font-faces: (
-  $font-name-serif 'type-serif-regular' 400 normal,
-  $font-name-sans 'type-sans-regular' 400 normal
-) !default;
+/*============================================================================*\
+   Typography mixins
+\*============================================================================*/
 
 /**
- * A map to define all font-sizes and their corresponding line-heights, the
+ * Responsive typograhy
+ * @author Mike Riethmuller http://codepen.io/MadeByMike/pen/YPJJYv
+ *
+ * @param  {integer} $min-width The minimum breakpoint
+ * @param  {integer} $max-width The maximum breakpoint
+ * @param  {integer} $min-size  The minimum font-size
+ * @param  {integer} $max-size  The maximum font-size
+ */
+@mixin responsive-type(
+  $min-width: 0,
+  $max-width: 2560,
+  $min-size: 12,
+  $max-size: 16
+) {
+  // Set min size
+  font-size: $min-size * 1px;
+
+  // Adjust size between `$min-width` et `$max-width`
+  @media (min-width: #{$min-width}px) and (max-width: #{$max-width}px) {
+    font-size: calc(
+      #{$min-size}px + (#{$max-size} - #{$min-size}) *
+        ((100vw - #{$min-width}px) / (#{$max-width} - #{$min-width}))
+    );
+  }
+
+  // Set max size
+  @media (min-width: #{$max-width}px) {
+    font-size: #{$max-size}px;
+  }
+}
+
+/**
+ * Antialiasing for better font rendering
+ */
+@mixin type-antialiased {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+@if $has-classes {
+  html,
+  input,
+  button,
+  .type-antialiased {
+    @include type-antialiased;
+  }
+}
+
+/**
+ * A map to define all type-sizes and their corresponding line-heights, the
  * first value is the font-size, the seconde the line-height.
  *
- * The `fz($font-size, $unit)` and the `lh($font-size)` functions below can be
+ * The `fz($type-size, $unit)` and the `lh($type-size)` functions below can be
  * used to get easily one of the two values.
  *
  * @type {Map}
  */
-$font-sizes: (
+$type-sizes: (
   'display-3': (
     44px,
     66px,
@@ -68,7 +110,7 @@ $font-sizes: (
 ) !default;
 
 /*============================================================================*\
-   Font-sizes helper function
+   Type sizes helper functions and mixins
 \*============================================================================*/
 
 /**
@@ -79,158 +121,80 @@ $font-sizes: (
  * @param  {number} $var   The modifier if needed
  * @return {number}        The corresponding z-index based on the $layers var
  */
-@function font-size($font-size, $unit: 'em') {
-  @if not map-has-key($font-sizes, $font-size) {
-    @error 'No font-size found in $fonti-sizes map for `#{$font-size}`.';
+@function font-size($type-size, $unit: 'em') {
+  @if not map-has-key($type-sizes, $type-size) {
+    @error 'No font-size found in $fonti-sizes map for `#{$type-size}`.';
   }
 
   $root-font-size: 16px;
-  $values: map-get($font-sizes, $font-size);
+  $values: map-get($type-sizes, $type-size);
 
   // First value is the font-size
-  $font-size: nth($values, 1);
+  $type-size: nth($values, 1);
 
   // Second value is the line-height, we divide it by the font-size to get
   // a line-height without unit, which is a best practice.
-  $line-height: nth($values, 2) / $font-size;
+  $line-height: nth($values, 2) / $type-size;
 
   @if $unit == 'px' {
-    @return $font-size;
+    @return $type-size;
   } @else {
-    @return #{$font-size / $root-font-size + $unit};
+    @return #{$type-size / $root-font-size + $unit};
   }
 }
 
 /**
- * Alias for the `font-size($font-size, $unit)` function above
+ * Alias for the `font-size($type-size, $unit)` function above
  */
-@function fz($font-size, $unit: 'em') {
-  @return font-size($font-size, $unit);
+@function fz($type-size, $unit: 'em') {
+  @return font-size($type-size, $unit);
 }
 
 /**
  * A function helper to get the computed line-height of the given font-size
- * @param  {string} $font-size The name of the font-size
+ * @param  {string} $type-size The name of the font-size
  * @return {string}            The corresponding line-height
  */
-@function line-height($font-size) {
-  @if not map-has-key($font-sizes, $font-size) {
-    @error 'No font-size found in $font-sizes map for `#{$font-size}`.';
+@function line-height($type-size) {
+  @if not map-has-key($type-sizes, $type-size) {
+    @error 'No font-size found in $type-sizes map for `#{$type-size}`.';
   }
 
-  $values: map-get($font-sizes, $font-size);
+  $values: map-get($type-sizes, $type-size);
 
   // First value is the font-size
-  $font-size: nth($values, 1);
+  $type-size: nth($values, 1);
 
   // Second value is the line-height, we divide it by the font-size to get
   // a line-height without unit, which is a best practice.
-  $line-height: nth($values, 2) / $font-size;
+  $line-height: nth($values, 2) / $type-size;
 
   @return $line-height;
 }
 
 /**
- * Alias for the `line-height($font-size)` function above
+ * Alias for the `line-height($type-size)` function above
  */
-@function lh($font-size) {
-  @return line-height($font-size);
+@function lh($type-size) {
+  @return line-height($type-size);
 }
 
 /**
  * A mixin to get both font-size and line-height given a named font-size
- * @param  {string} $font-size The font-size name
+ * @param  {string} $type-size The font-size name
  * @param  {string} $unit      The unit for the font-size value
  * @return {string}            The `font-size` and `line-height` declarations
  */
-@mixin font-size($font-size, $unit: 'em') {
-  font-size: fz($font-size, $unit);
-  line-height: lh($font-size);
+@mixin font-size($type-size, $unit: 'em') {
+  font-size: fz($type-size, $unit);
+  line-height: lh($type-size);
 }
 
 /**
- * Alias for the `font-size($font-size, $unit)` mixin defined above
+ * Alias for the `font-size($type-size, $unit)` mixin defined above
  */
-@mixin fz($font-size, $unit: 'em') {
-  @include font-size($font-size, $unit);
-}
-
-/*============================================================================*\
-   Fontaces declarations
-\*============================================================================*/
-@if $has-classes {
-  @each $font-face in $font-faces {
-    $name: nth($font-face, 1);
-    $file: nth($font-face, 2);
-    $weight: nth($font-face, 3);
-    $style: nth($font-face, 4);
-
-    @font-face {
-      font-family: $name;
-      src: url('#{$font-dir + $file}.woff2') format('woff2'),
-        url('#{$font-dir + $file}.woff') format('woff');
-      font-weight: $weight;
-      font-style: $style;
-      font-display: $font-display;
-    }
-  }
-}
-
-/*============================================================================*\
-   Responsive type mixin
-\*============================================================================*/
-
-/**
- * Responsive typograhy
- * @author Mike Riethmuller http://codepen.io/MadeByMike/pen/YPJJYv
- * @param  {integer} $min-width The minimum breakpoint
- * @param  {integer} $max-width The maximum breakpoint
- * @param  {integer} $min-size  The minimum font-size
- * @param  {integer} $max-size  The maximum font-size
- * @return {void}
- */
-@mixin responsive-type(
-  $min-width: 0,
-  $max-width: 2560,
-  $min-size: 12,
-  $max-size: 16
-) {
-  // Set min size
-  font-size: $min-size * 1px;
-
-  // Adjust size between `$min-width` et `$max-width`
-  @media (min-width: #{$min-width}px) and (max-width: #{$max-width}px) {
-    font-size: calc(
-      #{$min-size}px + (#{$max-size} - #{$min-size}) *
-        ((100vw - #{$min-width}px) / (#{$max-width} - #{$min-width}))
-    );
-  }
-
-  // Set max size
-  @media (min-width: #{$max-width}px) {
-    font-size: #{$max-size}px;
-  }
-}
-
-/*============================================================================*\
-   Antialiasing mixin
-\*============================================================================*/
-
-/**
- * Antialiasing for better font rendering
- */
-@mixin type-antialiased {
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
-@if $has-classes {
-  html,
-  input,
-  button,
-  .type-antialiased {
-    @include type-antialiased;
-  }
+@mixin fz($type-size, $unit: 'em') {
+  @include font-size($type-size, $unit);
 }
 
 /*============================================================================*\
@@ -238,8 +202,8 @@ $font-sizes: (
 \*============================================================================*/
 
 @if $has-classes {
-  @each $font-size in $font-sizes {
-    $key: nth($font-size, 1);
+  @each $type-size in $type-sizes {
+    $key: nth($type-size, 1);
 
     .type-#{$key} {
       @include fz($key);
@@ -252,8 +216,8 @@ $font-sizes: (
 
   // Media queries
   @include for-each-breakpoints using ($breakpoint) {
-    @each $font-size in $font-sizes {
-      $size: nth($font-size, 1);
+    @each $type-size in $type-sizes {
+      $size: nth($type-size, 1);
 
       .type-#{$size}--#{$breakpoint} {
         @include fz($size);
@@ -267,51 +231,115 @@ $font-sizes: (
 }
 
 /*============================================================================*\
-   Type alignement helpers
+   Type font families helpers
 \*============================================================================*/
 
+$type-webfont-dir: '/source/fonts/' !default;
+$type-webfont-display: auto !default;
+
+$type-fonts: (
+  serif: (
+    name: Georgia,
+    stack: 'Georgia, serif',
+    webfonts: (
+      (
+        filename: 'georgia-regular',
+        weight: 400,
+        style: normal,
+      ),
+      (
+        filename: 'georgia-italic',
+        weight: 400,
+        style: italic,
+      ),
+      (
+        filename: 'georgia-bold',
+        weight: 700,
+        style: normal,
+      ),
+      (
+        filename: 'georgia-bold-italic',
+        weight: 700,
+        style: italic,
+      ),
+    ),
+  ),
+  sans-serif: (
+    name: Arial,
+    stack: 'Arial, sans-serif',
+    webfonts: (
+      (
+        filename: 'arial-regular',
+        weight: 400,
+        style: normal,
+      ),
+      (
+        filename: 'arial-italic',
+        weight: 400,
+        style: italic,
+      ),
+      (
+        filename: 'arial-bold',
+        weight: 700,
+        style: normal,
+      ),
+      (
+        filename: 'arial-bold-italic',
+        weight: 700,
+        style: italic,
+      ),
+    ),
+  ),
+) !default;
+
 @if $has-classes {
-  .type-center {
-    text-align: center;
-  }
+  @each $font in $type-fonts {
+    $key: nth($font, 1);
+    $font: map-get($type-fonts, $key);
+    $name: map-get($font, 'name');
+    $stack: map-get($font, 'stack');
+    $webfonts: map-get($font, 'webfonts');
 
-  .type-left {
-    text-align: left;
-  }
-
-  .type-right {
-    text-align: right;
-  }
-
-  /**
-   * Generate helpers for each defined breakpoints
-   */
-  @include for-each-breakpoints using ($breakpoint) {
-    .type-center--#{$breakpoint} {
-      text-align: center;
+    .type-#{$key} {
+      font-family: unquote($stack);
     }
 
-    .type-left--#{$breakpoint} {
-      text-align: left;
-    }
+    @each $webfont in $webfonts {
+      $file: map-get($webfont, 'filename');
+      $weight: map-get($webfont, 'weight');
+      $style: map-get($webfont, 'style');
 
-    .type-right--#{$breakpoint} {
-      text-align: right;
+      @font-face {
+        font-family: $name;
+        src: url('#{$type-webfont-dir + $file}.woff2') format('woff2'),
+          url('#{$type-webfont-dir + $file}.woff') format('woff');
+        font-weight: $weight;
+        font-style: $style;
+        font-display: $type-webfont-display;
+      }
     }
   }
 }
 
 /*============================================================================*\
-   Type font families helpers
+   Type alignement helpers
 \*============================================================================*/
 
+$type-alignments: (left, center, right) !default;
+
 @if $has-classes {
-  .type-serif {
-    font-family: $font-family-serif;
+  @each $alignment in $type-alignments {
+    .type-align-#{$alignment} {
+      text-align: #{$alignment};
+    }
   }
 
-  .type-sans {
-    font-family: $font-family-sans;
+  @include for-each-breakpoints using ($breakpoint) {
+    @each $alignment in $type-alignments {
+      .type-align-#{$alignment}--#{$breakpoint} {
+        text-align: #{$alignment};
+      }
+    }
   }
 }
 
@@ -319,12 +347,12 @@ $font-sizes: (
    Type font weight helpers
 \*============================================================================*/
 
-$font-weights: (300, 400, 700) !default;
+$type-weights: (300, 400, 700) !default;
 
 @if $has-classes {
-  @each $font-weight in $font-weights {
-    .type-weight-#{$font-weight} {
-      font-weight: $font-weight;
+  @each $weight in $type-weights {
+    .type-weight-#{$weight} {
+      font-weight: $weight;
     }
   }
 
@@ -332,9 +360,9 @@ $font-weights: (300, 400, 700) !default;
    * Generate helpers for each defined breakpoints
    */
   @include for-each-breakpoints using ($breakpoint) {
-    @each $font-weight in $font-weights {
-      .type-weight-#{$font-weight}--#{$breakpoint} {
-        font-weight: $font-weight;
+    @each $weight in $type-weights {
+      .type-weight-#{$weight}--#{$breakpoint} {
+        font-weight: $weight;
       }
     }
   }
@@ -373,34 +401,26 @@ $type-spacings: (25, 50, 100, 200) !default;
    Type transform
 \*============================================================================*/
 
+$type-transforms: (uppercase, lowercase, capitalize) !default;
+
 @if $has-classes {
-  .type-uppercase {
-    text-transform: uppercase;
-  }
-
-  .type-lowercase {
-    text-transform: lowercase;
-  }
-
-  .type-capitalize {
-    text-transform: capitalize;
-  }
-
-  .type-no-underline {
-    text-decoration: none;
-  }
-
-  .type-underline {
-    text-decoration: underline;
+  @each $transform in $type-transforms {
+    .type-transform-#{$transform} {
+      text-transform: #{$transform};
+    }
   }
 }
 
 /*============================================================================*\
-   Type font defaults
+   Type decoration
 \*============================================================================*/
 
+$type-decorations: (none, underline) !default;
+
 @if $has-classes {
-  a {
-    color: inherit;
+  @each $decoration in $type-decorations {
+    .type-decoration-#{$decoration} {
+      text-decoration: #{$decoration};
+    }
   }
 }


### PR DESCRIPTION
Proposal to improve the typography configuration:

- All classes are generated by Sass maps which can be configured at will
- The font families are generated by a map, and their webfonts are specified in a child map with the following structure:

```sass
$type-fonts: (
  serif: (
    name: Georgia, // Used in the @font-face declaration
    stack: 'Georgia, sans-serif', // Used in the font-family declaration
    webfonts: (
      (
        filename: 'georgia-regular',
        weight: 400,
        style: normal,
      ),
      // ...
    ),
  ),
  sans-serif: (
    name: Arial,
    stack: 'Arial, sans-serif',
    webfonts: (
      (
        filename: 'arial-regular',
        weight: 400,
        style: normal,
      ),
      // ...
    ),
  ),  
) !default;
```