### PR TITLE
Improve helpers configuration

### DIFF
--- a/src/framework/_colors.scss
+++ b/src/framework/_colors.scss
@@ -3,6 +3,8 @@
 \*============================================================================*/
 
 $has-classes: false !default;
+$colors-with-force: false !default;
+$colors-with-breakpoints: false !default;
 $colors: (
   'white': #fff,
   'black': #000,
@@ -68,38 +70,78 @@ $colors: (
 
 @if $has-classes {
   @include for-each-colors using ($color, $value) {
-    // Global helpers
     .color-#{$color} {
       color: $value;
-    }
-
-    .color-#{$color}--force {
-      color: $value !important;
     }
 
     .background-#{$color} {
       background-color: $value;
     }
 
-    .background-#{$color}--force {
-      background-color: $value !important;
-    }
-
-    // SVG helpers
     .fill-#{$color} {
       fill: $value;
-    }
-
-    .fill-#{$color}--force {
-      fill: $value !important;
     }
 
     .stroke-#{$color} {
       stroke: $value;
     }
 
-    .stroke-#{$color}--force {
-      stroke: $value !important;
+    @if $colors-with-force {
+      .color-#{$color}--force {
+        color: $value !important;
+      }
+
+      .background-#{$color}--force {
+        background-color: $value !important;
+      }
+
+      .fill-#{$color}--force {
+        fill: $value !important;
+      }
+
+      .stroke-#{$color}--force {
+        stroke: $value !important;
+      }
+    }
+  }
+
+  @if $colors-with-breakpoints {
+    @include for-each-breakpoints using ($breakpoint) {
+      @include for-each-colors using ($color, $value) {
+        .color-#{$color}--#{$breakpoint} {
+          color: $value;
+        }
+
+        .background-#{$color}--#{$breakpoint} {
+          background-color: $value;
+        }
+
+        .fill-#{$color}--#{$breakpoint} {
+          fill: $value;
+        }
+
+        .stroke-#{$color}--#{$breakpoint} {
+          stroke: $value;
+        }
+
+        @if $colors-with-force {
+          .color-#{$color}--force-#{$breakpoint} {
+            color: $value !important;
+          }
+
+          .background-#{$color}--force-#{$breakpoint} {
+            background-color: $value !important;
+          }
+
+          .fill-#{$color}--force-#{$breakpoint} {
+            fill: $value !important;
+          }
+
+          .stroke-#{$color}--force-#{$breakpoint} {
+            stroke: $value !important;
+          }
+        }
+      }
     }
   }
 }

--- a/src/framework/_displays.scss
+++ b/src/framework/_displays.scss
@@ -3,6 +3,8 @@
 \*============================================================================*/
 
 $has-classes: false !default;
+$displays-with-force: false !default;
+$displays-with-breakpoints: false !default;
 $displays: (none, block, inline, inline-block) !default;
 
 /*============================================================================*\
@@ -34,8 +36,10 @@ $displays: (none, block, inline, inline-block) !default;
       display: $display;
     }
 
-    .display-#{$display}--force {
-      display: $display !important;
+    @if $displays-with-force {
+      .display-#{$display}--force {
+        display: $display !important;
+      }
     }
   }
 
@@ -47,19 +51,23 @@ $displays: (none, block, inline, inline-block) !default;
      Visibility breakpoints modifiers
   \*==========================================================================*/
 
-  @include for-each-breakpoints using ($breakpoint) {
-    @each $display in $displays {
-      .display-#{$display}--#{$breakpoint} {
-        display: $display;
+  @if $displays-with-breakpoints {
+    @include for-each-breakpoints using ($breakpoint) {
+      @each $display in $displays {
+        .display-#{$display}--#{$breakpoint} {
+          display: $display;
+        }
+
+        @if $displays-with-force {
+          .display-#{$display}--force-#{$breakpoint} {
+            display: $display !important;
+          }
+        }
       }
 
-      .display-#{$display}--force-#{$breakpoint} {
-        display: $display !important;
+      .display-hidden-accessible {
+        @include display-hidden-accessible();
       }
-    }
-
-    .display-hidden-accessible {
-      @include display-hidden-accessible();
     }
   }
 }

--- a/src/framework/_index.scss
+++ b/src/framework/_index.scss
@@ -13,3 +13,4 @@ $has-classes: false !default;
 @import 'spaces';
 @import 'displays';
 @import 'typography';
+@import 'opacities';

--- a/src/framework/_index.scss
+++ b/src/framework/_index.scss
@@ -14,3 +14,4 @@ $has-classes: false !default;
 @import 'displays';
 @import 'typography';
 @import 'opacities';
+@import 'positions';

--- a/src/framework/_layers.scss
+++ b/src/framework/_layers.scss
@@ -3,7 +3,8 @@
 \*============================================================================*/
 
 $has-classes: false !default;
-
+$layers-with-force: false !default;
+$layers-with-breakpoints: false !default;
 $layers: (
   goku: 9000,
   modal: 6000,
@@ -86,20 +87,26 @@ $layers: (
       z-index: $value;
     }
 
-    .layer-#{$layer}--force {
-      z-index: $value !important;
+    @if $layers-with-force {
+      .layer-#{$layer}--force {
+        z-index: $value !important;
+      }
     }
   }
 
   // Media queries
-  @include for-each-breakpoints using ($breakpoint) {
-    @include for-each-layers using ($layer, $value) {
-      .layer-#{$layer}--#{$breakpoint} {
-        z-index: $value;
-      }
+  @if $layers-with-breakpoints {
+    @include for-each-breakpoints using ($breakpoint) {
+      @include for-each-layers using ($layer, $value) {
+        .layer-#{$layer}--#{$breakpoint} {
+          z-index: $value;
+        }
 
-      .layer-#{$layer}--force-#{$breakpoint} {
-        z-index: $value !important;
+        @if $layers-with-force {
+          .layer-#{$layer}--force-#{$breakpoint} {
+            z-index: $value !important;
+          }
+        }
       }
     }
   }

--- a/src/framework/_opacities.scss
+++ b/src/framework/_opacities.scss
@@ -1,0 +1,82 @@
+/*============================================================================*\
+   Opacities
+\*============================================================================*/
+
+$has-classes: false !default;
+$opacities-with-breakpoints: true !default;
+$opacities: (0, 25, 50, 75, 100) !default;
+
+/*============================================================================*\
+   Functions
+\*============================================================================*/
+
+/**
+ * A function helper to simplify the usage of opacities
+ *
+ * @param  {string} $opacity  The 100 based opacity value
+ * @return {number}           The 1 based computed opacity
+ */
+@function opacity($opacity) {
+  // Find the index of the given space
+  $index: index($opacities, $opacity);
+
+  // If no index, there is no opacity defined with this name, we throw an error
+  @if not $index {
+    @error 'No opacity of size `#{$opacity}` found in the `$opacities` list.';
+  }
+
+  // Get the value of the opacity
+  $value: nth($opacities, $index);
+  @return $value / 100;
+}
+
+/**
+ * Alias for the `opacity($opacity)` function above
+ */
+@function o($opacity) {
+  @return o($opacity);
+}
+
+/*============================================================================*\
+   Mixins
+\*============================================================================*/
+
+/**
+ * Abstract loop over all spaces with the possibility to exclude some
+ *
+ * @param  {ArgList} $excludes The colors to exclude from the loop
+ *
+ * @author Titouan Mathis <titouan@studiometa.fr>
+ * @since  1.2.0
+ */
+@mixin for-each-opacities($excludes...) {
+  @each $opacity in $opacities {
+    $value: opacity($opacity);
+
+    @if not index($excludes, $opacity) {
+      @content ($opacity, $value);
+    }
+  }
+}
+
+/*============================================================================*\
+   Helper classes
+\*============================================================================*/
+
+@if $has-classes {
+  @include for-each-opacities using ($opacity, $value) {
+    .opacity-#{$opacity} {
+      opacity: $value;
+    }
+  }
+
+  @if $opacities-with-breakpoints {
+    @include for-each-breakpoints using ($breakpoint) {
+      @include for-each-opacities using ($opacity, $value) {
+        .opacity-#{$opacity}--#{$breakpoint} {
+          opacity: $value;
+        }
+      }
+    }
+  }
+}

--- a/src/framework/_positions.scss
+++ b/src/framework/_positions.scss
@@ -1,0 +1,95 @@
+/*============================================================================*\
+   Positions
+\*============================================================================*/
+
+$has-classes: false !default;
+$positions-with-force: false !default;
+$positions-with-breakpoints: false !default;
+$positions: (static, relative, absolute) !default;
+
+/*============================================================================*\
+   Functions
+\*============================================================================*/
+
+/**
+ * A function helper to simplify the usage of positions
+ *
+ * @param  {string} $position  The position value
+ * @return {number}            The position value
+ */
+@function position($position) {
+  // Find the index of the given space
+  $index: index($positions, $position);
+
+  // If no index, there is no position defined with this name, we throw an error
+  @if not $index {
+    @error 'No position of size `#{$position}` found in the `$positions` list.';
+  }
+
+  // Get the value of the position
+  $value: nth($positions, $index);
+  @return $value / 100;
+}
+
+/**
+ * Alias for the `position($position)` function above
+ */
+@function p($position) {
+  @return p($position);
+}
+
+/*============================================================================*\
+   Mixins
+\*============================================================================*/
+
+/**
+ * Abstract loop over all spaces with the possibility to exclude some
+ *
+ * @param  {ArgList} $excludes The colors to exclude from the loop
+ *
+ * @author Titouan Mathis <titouan@studiometa.fr>
+ * @since  1.2.0
+ */
+@mixin for-each-positions($excludes...) {
+  @each $position in $positions {
+    $value: position($position);
+
+    @if not index($excludes, $position) {
+      @content ($position);
+    }
+  }
+}
+
+/*============================================================================*\
+   Helper classes
+\*============================================================================*/
+
+@if $has-classes {
+  @include for-each-positions using ($position) {
+    .position-#{$position} {
+      position: $position;
+    }
+
+    @if $positions-with-force {
+      .position-#{$position}--force {
+        position: $position !important;
+      }
+    }
+  }
+
+  @if $positions-with-breakpoints {
+    @include for-each-breakpoints using ($breakpoint) {
+      @include for-each-positions using ($position) {
+        .position-#{$position}--#{$breakpoint} {
+          position: $position;
+        }
+
+        @if $positions-with-force {
+          .position-#{$position}--force-#{$breakpoint} {
+            position: $position !important;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Proposal for a more tailored configuration the classes generated. The colors, displays and layers helpers can now be generated with (or without) the `--force` and `--<breakpoint>` modifiers by setting the value of the following variables:

```sass
$colors-with-force: false !default;
$colors-with-breakpoints: false !default;

$displays-with-force: false !default;
$displays-with-breakpoints: false !default;

$layers-with-force: false !default;
$layers-with-breakpoints: false !default;
```
---
This PR also includes a proposal for a new set of opacity utility classes (see 692ba66).