### PR TITLE
Add a base font-size variable to calculate type sizes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -480,6 +480,7 @@ $spaces: (0, 1, 2, 4, 8, 16, auto);
 - `@mixin font-size($font-size, $unit: 'em')`: a mixin to get CSS properties of the given name defined in the `$font-size` map
 - `@mixin fz($font-size, $unit: 'em')`: alias for the `@include font-size($font-size, $unit)` mixin
 - `$type-webfont-dir`: path to the folder of your webfont files (which must be of `*.woff` and `*.woff2` formats)
+- `$font-size-root`: the root font size applied to `html` DOM element, used to calculate others font sizes
 - `$type-webfont-display`: the `font-display` property that will be applied to the `@font-faces` declarations
 - `$type-fonts: (<identifier>: <definition>)`: a map of font identifiers
   + `<identifier>`: a unique font name, will be used to generate helper classes
@@ -515,6 +516,9 @@ $spaces: (0, 1, 2, 4, 8, 16, auto);
 **Defaults**
 
 ```scss
+/** @type {String} Root font size, used to calculate others font sizes */
+$font-size-root: 16px !default;
+
 /**
  * A map to define all type-sizes and their corresponding line-heights, the
  * first value is the font-size, the seconde the line-height.

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -5,6 +5,16 @@
 /** @type {Boolean} Do we need classes? */
 $has-classes: false !default;
 
+/** @type {String} Root font size, used to calculate others font sizes */
+$font-size-root: 16px !default;
+
+@if $has-classes {
+  // Set root font size
+  html {
+    font-size: $font-size-root;
+  }
+}
+
 /*============================================================================*\
    Generic mixins
 \*============================================================================*/
@@ -123,7 +133,7 @@ $type-sizes: (
     @if $unit == 'px' {
       font-size: $font-size;
     } @else {
-      font-size: #{($font-size / 16px) + $unit};
+      font-size: #{$font-size / $font-size-root + $unit};
     }
 
     @if map-has-key($type-size, 'weight') {

--- a/tests/src/_config.scss
+++ b/tests/src/_config.scss
@@ -1,3 +1,4 @@
+$font-size-root: 18px;
 $spaces-base: 8px / 16px * 1rem;
 $spaces: (0, 1, 2, 4, 8, 16, auto);
 


### PR DESCRIPTION
Add a base font-size variable to calculate type sizes rather than use default size (16px)