### PR TITLE
Feature/responsive type size

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -472,7 +472,7 @@ $spaces: (0, 1, 2, 4, 8, 16, auto);
 
 - `@mixin reponsize-type($min-width: 0, $max-width: 2560, $min-size: 12, $max-size: 16)`: a mixin to generate declaration for responsive font-sizes
 - `@mixin type-antialiased`: a mixin to generate properties for antialiased font rendering
-- `$type-sizes`: a map of font-sizes lists to be used in your project structured as `<name>: ( size: <font-size>[, line-height: <line-height>][, weight: <font-weight>])`
+- `$type-sizes`: a map of font-sizes lists to be used in your project structured as `<name>: ( size: <font-size>[, line-height: <line-height>][, weight: <font-weight>] )` or `<name>: ( default: ( size: <font-size>[, line-height: <line-height>][, weight: <font-weight>] ), <breakpoint>: ( ... ) )` for responsive type sizes
   + `<name>`: the name of the size
   + `<font-size>`: the `font-size` value in pixels
   + `<line-height>`: the `line-height` value in pixels
@@ -494,9 +494,8 @@ $spaces: (0, 1, 2, 4, 8, 16, auto);
 - `@function ff($type-font)`: alias for the above `font-family($type-font)` function
 - Class helpers:
   + `.type-antialiased`: a class implementing the `type-antialiased` mixin
-  + `.type[-rem]-<size>[--<breakpoint>]`: set the `font-size` in `em` and `line-height` properties to the given `<size>` defined values, with the `-rem` variation setting the `font-size` unit in `rem` and the `<breakpoint>` modifier applying the styles to the corresponding breakpoint
+  + `.type[-rem]-<size>`: set the `font-size` in `em` and `line-height` properties to the given `<size>` defined values, with the `-rem` variation setting the `font-size` unit in `rem`
     * `<size>`: a name defined in the `$font-sizes` map
-    * `<breakpoint>`: a breakpoint's name defined in the `$breakpoints` map
   + `.type-<font-name>`: set the `font-family` property to the corresponding stack in the `$type-fonts` map
     * `<font-name>`: the unique identifier given to the font
   + `.type-align-<alignment>[--<breakpoint>]`: set the `text-align` property, with the `<breakpoint>` modifier applying the styles to the corresponding breakpoint
@@ -524,9 +523,11 @@ $spaces: (0, 1, 2, 4, 8, 16, auto);
  */
 $type-sizes: (
   display-1: (
-    size: 32px,
-    line-height: 48px,
-    weight: 700,
+    default: (
+      size: 32px,
+      line-height: 48px,
+      weight: 700,
+    ),
   ),
   display-2: (
     size: 24px,

--- a/src/framework/_typography.scss
+++ b/src/framework/_typography.scss
@@ -71,9 +71,11 @@ $has-classes: false !default;
  */
 $type-sizes: (
   display-1: (
-    size: 32px,
-    line-height: 48px,
-    weight: 700,
+    default: (
+      size: 32px,
+      line-height: 48px,
+      weight: 700,
+    ),
   ),
   display-2: (
     size: 24px,
@@ -95,34 +97,50 @@ $type-sizes: (
  * @param  {string} $unit      The unit for the font-size value
  * @return {string}            The `font-size` and `line-height` declarations
  */
-@mixin font-size($type-size, $unit: 'em') {
+@mixin font-size($type-size, $unit: 'em', $breakpoint: 'default') {
   @if not map-has-key($type-sizes, $type-size) {
-    @error 'No font-size found in $type-sizes map for `#{$type-size}`.';
+    @error 'No font-size definition found in $type-sizes map for `#{$type-size}`.';
   }
 
-  $type-size: map-get($type-sizes, $type-size);
-  $font-size: map-get($type-size, 'size');
+  $type-size-definition: map-get($type-sizes, $type-size);
 
-  @if $unit == 'px' {
-    font-size: $font-size;
+  // 1. Get the wanted breakpoint defintion if its key exists.
+  // 2. If the key does not exists and the $breakpoint value is default, the
+  // font size definition has no breakpoint definition.
+  // 3. If the 2 preceding condition are not met, there is no size corresponding
+  // to the parameters, so do nothing.
+  @if map-has-key($type-size-definition, $breakpoint) {
+    $type-size: map-get($type-size-definition, $breakpoint);
+  } @else if $breakpoint == 'default' {
+    $type-size: $type-size-definition;
   } @else {
-    font-size: #{$font-size / 16px + $unit};
+    $type-size: false;
   }
 
-  @if map-has-key($type-size, 'weight') {
-    font-weight: map-get($type-size, 'weight');
-  }
+  @if not $type-size == false {
+    $font-size: map-get($type-size, 'size');
 
-  @if map-has-key($type-size, 'line-height') {
-    line-height: map-get($type-size, 'line-height') / $font-size;
+    @if $unit == 'px' {
+      font-size: $font-size;
+    } @else {
+      font-size: #{($font-size / 16px) + $unit};
+    }
+
+    @if map-has-key($type-size, 'weight') {
+      font-weight: map-get($type-size, 'weight');
+    }
+
+    @if map-has-key($type-size, 'line-height') {
+      line-height: map-get($type-size, 'line-height') / $font-size;
+    }
   }
 }
 
 /**
  * Alias for the `font-size($type-size, $unit)` mixin defined above
  */
-@mixin fz($type-size, $unit: 'em') {
-  @include font-size($type-size, $unit);
+@mixin fz($type-size, $unit: 'em', $breakpoint: 'default') {
+  @include font-size($type-size, $unit, $breakpoint);
 }
 
 /* Class helpers
@@ -134,24 +152,19 @@ $type-sizes: (
 
     .type-#{$key} {
       @include fz($key);
+
+      // Media queries
+      @include for-each-breakpoints using ($breakpoint) {
+        @include fz($key, 'em', $breakpoint);
+      }
     }
 
     .type-rem-#{$key} {
       @include fz($key, 'rem');
-    }
-  }
 
-  // Media queries
-  @include for-each-breakpoints using ($breakpoint) {
-    @each $type-size in $type-sizes {
-      $size: nth($type-size, 1);
-
-      .type-#{$size}--#{$breakpoint} {
-        @include fz($size);
-      }
-
-      .type-rem-#{$size}--#{$breakpoint} {
-        @include fz($size);
+      // Media queries
+      @include for-each-breakpoints using ($breakpoint) {
+        @include fz($key, 'rem', $breakpoint);
       }
     }
   }

--- a/tests/src/_config.scss
+++ b/tests/src/_config.scss
@@ -15,6 +15,30 @@ $breakpoints: (
   'extra-large': 2000,
 );
 
+$type-sizes: (
+  display-1: (
+    default: (
+      size: 32px,
+      line-height: 48px,
+      weight: 700,
+    ),
+    small: (
+      size: 48px,
+    ),
+  ),
+  display-2: (
+    size: 24px,
+    line-height: 36px,
+    weight: 700,
+  ),
+  body: (
+    size: 16px,
+  ),
+  small: (
+    size: 12px,
+  ),
+);
+
 @import '../../src/framework/index';
 
 $grid-gutters: (


### PR DESCRIPTION
This feature adds a responsive configuration for the type size defintions. 

The toolkit will no longer generate breakpoints classes for the type size classes but will instead apply media queries to each classes.

The following configuration:

```scss
$type-sizes: (
  title: (
    default: (
      size: 24px,
      weight: 700,
    ),
    m: (
      size: 32px,
    ),
    xl: (
      size: 40px,
    ),
  ),
  labor: (
    size: 18px,
    line-height: 24px,
  ),
);
```

Will now output the following CSS:

```css
.type-title {
  font-size: 1.5em;
  font-weight: 700
}
@media (min-width:64em) {
  .type-title {
    font-size: 2em
  }
}
@media (min-width:90em) {
  .type-title {
    font-size: 2.5em
  }
}
.type-rem-title {
  font-size: 1.5rem;
  font-weight: 700
}
@media (min-width:64em) {
  .type-rem-title {
    font-size: 2rem
  }
}
@media (min-width:90em) {
  .type-rem-title {
    font-size: 2.5rem
  }
}
.type-labor {
  font-size: 1.125em;
  line-height: 1.3333333333
}
.type-rem-labor {
  font-size: 1.125rem;
  line-height: 1.3333333333
}
```